### PR TITLE
Change error behavior in terraform-ci

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -40,7 +40,6 @@ on:
 jobs:
   format:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## what
* Remove continue on error

## why
* It makes the workflow have result 'success' even if that step failed
* Initially I had this when all of these jobs were `steps` in my testing environment, and I needed to ensure I run lint even if format failed. It's not needed anymore because these are now `jobs` and they all run in parallel unconditionally anyways. 

