### PR TITLE
Use PAT for scheduled workflows

### DIFF
--- a/.github/workflows/scheduled-context.yml
+++ b/.github/workflows/scheduled-context.yml
@@ -31,6 +31,10 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
+    secrets:
+      github_access_token:
+        description: "GitHub API token"
+        required: true
 
 jobs:
   update:
@@ -80,3 +84,6 @@ jobs:
         labels: |
           auto-update
           context
+        # Using PAT, otherwise PR won't trigger other workflows
+        # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+        token: ${{ secrets.github_access_token }}

--- a/.github/workflows/scheduled-readme.yml
+++ b/.github/workflows/scheduled-readme.yml
@@ -31,6 +31,10 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
+    secrets:
+      github_access_token:
+        description: "GitHub API token"
+        required: true
 
 jobs:
   update:
@@ -72,3 +76,6 @@ jobs:
           auto-update
           no-release
           readme
+        # Using PAT, otherwise PR won't trigger other workflows
+        # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+        token: ${{ secrets.github_access_token }}


### PR DESCRIPTION
## what
* Use PAT for scheduled

## why
* To let auto-generated PR automatically trigger other workflows. 

## references
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
