### PR TITLE
Allow override token in release controller

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -34,6 +34,11 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
+    secrets:
+      github_access_token:
+        description: "GitHub API token"
+        default: ${{ secrets.GITHUB_TOKEN }}
+        required: false
 
 jobs:
   release:
@@ -55,4 +60,4 @@ jobs:
           config-name: ${{ inputs.config-name }}
           commitish: ${{ inputs.ref }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.github_access_token }}

--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -37,7 +37,6 @@ on:
     secrets:
       github_access_token:
         description: "GitHub API token"
-        default: ${{ secrets.GITHUB_TOKEN }}
         required: false
 
 jobs:
@@ -60,4 +59,4 @@ jobs:
           config-name: ${{ inputs.config-name }}
           commitish: ${{ inputs.ref }}
         env:
-          GITHUB_TOKEN: ${{ secrets.github_access_token }}
+          GITHUB_TOKEN: ${{ secrets.github_access_token || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## what
* Allow override github token in release controller

## why
* If you want release-controller to trigger other events like release-published or tag-pushed you need to use PAT instead of workflow generated token. 

