### PR TITLE
Do not fail tflint when suggestions are disabled

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -107,7 +107,7 @@ jobs:
         uses: reviewdog/action-tflint@v1.18.0
         with:
           reporter: ${{ inputs.suggestions && 'github-pr-review' || 'local' }}
-          fail_on_error: ${{ inputs.suggestion }}
+          fail_on_error: ${{ inputs.suggestions }}
           tflint_rulesets: ${{ env.TFLINT_PLUGINS }}
           tflint_init: true
           working_directory: ${{ matrix.tfdir }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -107,7 +107,7 @@ jobs:
         uses: reviewdog/action-tflint@v1.18.0
         with:
           reporter: ${{ inputs.suggestions && 'github-pr-review' || 'local' }}
-          fail_on_error: ${{ inputs.suggestions }}
+          fail_on_error: ${{ inputs.suggestions }}  # Set to true when all tflint issues are fixed in all tf repos main branches
           tflint_rulesets: ${{ env.TFLINT_PLUGINS }}
           tflint_init: true
           working_directory: ${{ matrix.tfdir }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -107,7 +107,7 @@ jobs:
         uses: reviewdog/action-tflint@v1.18.0
         with:
           reporter: ${{ inputs.suggestions && 'github-pr-review' || 'local' }}
-          fail_on_error: true
+          fail_on_error: ${{ inputs.suggestion }}
           tflint_rulesets: ${{ env.TFLINT_PLUGINS }}
           tflint_init: true
           working_directory: ${{ matrix.tfdir }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -107,7 +107,7 @@ jobs:
         uses: reviewdog/action-tflint@v1.18.0
         with:
           reporter: ${{ inputs.suggestions && 'github-pr-review' || 'local' }}
-          fail_on_error: ${{ inputs.suggestions }}  # Set to true when all tflint issues are fixed in all tf repos main branches
+          fail_on_error: ${{ inputs.suggestions }}  # Set to true when all tflint issues are fixed in all tf repo release branches
           tflint_rulesets: ${{ env.TFLINT_PLUGINS }}
           tflint_init: true
           working_directory: ${{ matrix.tfdir }}


### PR DESCRIPTION
  ## what
* Do not fail tflint when suggestions are off (fixing the release workflow)

## why
* Filter-mode (we use `context`) is ignored when reporting mode is `local`. When filter mode is ignored - it will fail if any of the files have issues , not only changed since the last release. In practice this means we can't release a repo if it has at least a single tflint error - almost all our repos have some minor tflint issues.

## references
* https://github.com/cloudposse/terraform-aws-dynamic-subnets/actions/runs/5015742223/jobs/8991708296 needs re-run after merge
