### PR TITLE
Exclude obsolete examples from Terraform linting

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -66,8 +66,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - id: set-matrix
+        # Ignore directories whose names start with .terraform or obsolete
         run: |
-          matrix=$(find ./ -name '*.tf' \
+          matrix=$(find .  -type d \( -name '.terraform*' -o -name 'obsolete*' \) -prune -o \
+            -name '*.tf' \
             -not -path '*/.terraform/*' \
             -exec dirname {} \; \
             | sort \

--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Fetch pull request for the given ref
         id: get-pull-request
-        uses: 8BitJonny/gh-get-current-pr@2.2.0
+        uses: 8BitJonny/gh-get-current-pr@3.0.0
         with:
           sha: ${{ inputs.sha }}
 


### PR DESCRIPTION
## what

- Exclude directories whose names begin with "obsolete" from Terraform linting
- Update `8BitJonny/gh-get-current-pr` from v2.2.0 to v3.0.0

## why

- Enable historical examples for old versions of modules to be published without requiring modern linting standards. In particular, allow version pinning.
- Migrate to node20

