### PR TITLE
Added input runs-on

### DIFF
--- a/.github/workflows/cd-argocd.yml
+++ b/.github/workflows/cd-argocd.yml
@@ -65,6 +65,11 @@ on:
         description: Helmfile values file
         default: ''
         required: false
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -79,7 +84,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment:
       name: ${{ inputs.environment }}
       url: ${{ steps.deploy.outputs.webapp-url }}

--- a/.github/workflows/cd-atmos-stack-deploy.yml
+++ b/.github/workflows/cd-atmos-stack-deploy.yml
@@ -31,9 +31,14 @@ on:
         description: Environment.
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 jobs:
   plan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment:
       name: ${{ inputs.environment }}
     steps:

--- a/.github/workflows/cd-ecs.yml
+++ b/.github/workflows/cd-ecs.yml
@@ -62,6 +62,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -82,7 +87,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment:
       name: ${{ inputs.environment }}
       url: ${{ steps.deploy.outputs.webapp-url }}

--- a/.github/workflows/cd-ecspresso.yml
+++ b/.github/workflows/cd-ecspresso.yml
@@ -72,6 +72,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -86,7 +91,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment:
       name: ${{ inputs.environment }}
       url: ${{ steps.result.outputs.webapp-url }}

--- a/.github/workflows/cd-helmfile.yml
+++ b/.github/workflows/cd-helmfile.yml
@@ -47,7 +47,7 @@ on:
         description: "Overrides job runs-on setting (json-encoded list)"
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"

--- a/.github/workflows/cd-helmfile.yml
+++ b/.github/workflows/cd-helmfile.yml
@@ -43,6 +43,11 @@ on:
         description: "Environment name deploy to"
         type: string
         required: true
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -57,7 +62,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ["self-hosted"]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment:
       name: ${{ inputs.environment }}
       url: ${{ steps.deploy.outputs.webapp-url }}

--- a/.github/workflows/cd-preview-argocd.yml
+++ b/.github/workflows/cd-preview-argocd.yml
@@ -91,6 +91,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: false
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -107,7 +112,7 @@ permissions:
 
 jobs:
   preview:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Preview deployments controller
         uses: cloudposse/github-action-preview-environment-controller@0.11.0

--- a/.github/workflows/cd-preview-ecs.yml
+++ b/.github/workflows/cd-preview-ecs.yml
@@ -91,6 +91,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -113,7 +118,7 @@ permissions:
 
 jobs:
   preview:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Preview deployments controller
         uses: cloudposse/github-action-preview-environment-controller@0.11.0

--- a/.github/workflows/cd-preview-ecspresso.yml
+++ b/.github/workflows/cd-preview-ecspresso.yml
@@ -97,6 +97,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -114,7 +119,7 @@ permissions:
 jobs:
   preview:
     name: preview // controller
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Preview deployments controller
         uses: cloudposse/github-action-preview-environment-controller@0.11.0
@@ -131,7 +136,7 @@ jobs:
       destroy_envs: ${{ steps.controller.outputs.destroy_envs }}
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     if: ${{ needs.preview.outputs.deploy_envs != '[]'  }}
     strategy:
       matrix:
@@ -281,7 +286,7 @@ jobs:
           echo "webapp-url=${SSM_URL_0}" >> $GITHUB_OUTPUT
 
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     if: ${{ needs.preview.outputs.destroy_envs != '[]'  }}
     strategy:
       matrix:

--- a/.github/workflows/cd-preview-helmfile.yml
+++ b/.github/workflows/cd-preview-helmfile.yml
@@ -73,7 +73,7 @@ on:
         description: "Overrides job runs-on setting (json-encoded list)"
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"

--- a/.github/workflows/cd-preview-helmfile.yml
+++ b/.github/workflows/cd-preview-helmfile.yml
@@ -69,6 +69,11 @@ on:
         type: string
         default: |
           preview: deploy
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -85,7 +90,7 @@ permissions:
 
 jobs:
   preview:
-    runs-on: ["self-hosted"]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Preview deployments controller
         uses: cloudposse/github-action-preview-environment-controller@0.11.0
@@ -103,7 +108,7 @@ jobs:
 
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [ preview ]
     if: ${{ needs.preview.outputs.deploy_envs != '[]'  }}
     strategy:
@@ -166,7 +171,7 @@ jobs:
 
 
   destroy:
-    runs-on: ["self-hosted"]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [ preview ]
     if: ${{ needs.preview.outputs.destroy_envs != '[]'  }}
     strategy:

--- a/.github/workflows/ci-atmos-stack-plan.yml
+++ b/.github/workflows/ci-atmos-stack-plan.yml
@@ -27,9 +27,14 @@ on:
         description: The component name.
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 jobs:
   plan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       # This is just to mock calling terraform plan. In reality, this would be a call to `atmos terraform plan`
       - run: echo "atmos terraform plan ${{inputs.component}} -s ${{inputs.stack}}"

--- a/.github/workflows/ci-dockerized-app-build.yml
+++ b/.github/workflows/ci-dockerized-app-build.yml
@@ -39,6 +39,11 @@ on:
         type: boolean
         default: true
         required: false
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       ecr-region:
         description: "ECR AWS region"
@@ -67,7 +72,7 @@ permissions:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -98,7 +103,7 @@ jobs:
       tag: ${{ steps.build.outputs.tag }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     if: ${{ inputs.tests_enabled }}
     needs: [ build ]
     steps:

--- a/.github/workflows/ci-dockerized-app-promote-or-build.yml
+++ b/.github/workflows/ci-dockerized-app-promote-or-build.yml
@@ -52,6 +52,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       ecr-region:
         description: "ECR AWS region"
@@ -80,7 +85,7 @@ permissions:
 jobs:
   promote-or-build:
     name: promote or build
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2
@@ -157,7 +162,7 @@ jobs:
       tag: ${{ fromJson(steps.outputs.outputs.result).tag }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     if: ${{ needs.promote-or-build.outputs.builded == 'true' }}
     needs: [ promote-or-build ]
     steps:

--- a/.github/workflows/ci-dockerized-app-promote.yml
+++ b/.github/workflows/ci-dockerized-app-promote.yml
@@ -53,6 +53,11 @@ on:
         description: "Matrix key - matrix output workaround. [Read more](https://github.com/cloudposse/github-action-matrix-outputs-write#introduction)"
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       ecr-region:
         description: "ECR AWS region"
@@ -80,7 +85,7 @@ permissions:
 
 jobs:
   promote:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2

--- a/.github/workflows/ci-dockerized-app-verify.yml
+++ b/.github/workflows/ci-dockerized-app-verify.yml
@@ -45,6 +45,11 @@ on:
         description: "Release version tag"
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       ecr-region:
         description: "ECR AWS region"
@@ -72,7 +77,7 @@ permissions:
 
 jobs:
   pull:
-    runs-on: ["self-hosted"]
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.2

--- a/.github/workflows/ci-dockerized-app-verify.yml
+++ b/.github/workflows/ci-dockerized-app-verify.yml
@@ -49,7 +49,7 @@ on:
         description: "Overrides job runs-on setting (json-encoded list)"
         type: string
         required: false
-        default: '["ubuntu-latest"]'
+        default: '["self-hosted"]'
     secrets:
       ecr-region:
         description: "ECR AWS region"

--- a/.github/workflows/ci-typescript-app-check-dist.yml
+++ b/.github/workflows/ci-typescript-app-check-dist.yml
@@ -50,10 +50,15 @@ on:
         required: false
         type: string
         default: "yarn"
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
 jobs:
   check-dist:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
 
     permissions:
       contents: write

--- a/.github/workflows/controller-atmos-affected-stacks.yml
+++ b/.github/workflows/controller-atmos-affected-stacks.yml
@@ -23,6 +23,11 @@ on:
         description: The head ref to checkout. If not provided, the head default branch is used.
         type: string
         required: false
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     outputs:
       stacks:
         description: "Affected stacks"
@@ -33,7 +38,7 @@ on:
 
 jobs:
   get-affected-property-stacks:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       has-affected-stacks: ${{ steps.matrix.outputs.matrix!='{"include":[]}'}}

--- a/.github/workflows/controller-atmos-github-workflows.yml
+++ b/.github/workflows/controller-atmos-github-workflows.yml
@@ -23,10 +23,15 @@ on:
         description: Stacks
         required: false
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
 jobs:
   create-files:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/controller-draft-release.yml
+++ b/.github/workflows/controller-draft-release.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: ${{ github.sha }}
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
     secrets:
       github-private-actions-pat:
@@ -36,7 +41,7 @@ on:
         required: true
 jobs:
   draft:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Create/Update Draft release

--- a/.github/workflows/controller-hotfix-reintegrate.yml
+++ b/.github/workflows/controller-hotfix-reintegrate.yml
@@ -33,13 +33,18 @@ on:
         required: false
         type: string
         default: main
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     secrets:
       github-private-actions-pat:
         description: "Github PAT allow to create a pull request"
         required: true
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/controller-hotfix-release-branch.yml
+++ b/.github/workflows/controller-hotfix-release-branch.yml
@@ -25,10 +25,15 @@ on:
         description: "Release version"
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
 
 jobs:
   release-branch:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/controller-hotfix-release.yml
+++ b/.github/workflows/controller-hotfix-release.yml
@@ -24,13 +24,18 @@ on:
         description: "The fully-formed ref of the branch or tag that triggered the workflow run"
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     outputs:
       version:
         description: Release version
         value: ${{ jobs.create.outputs.version }}
 jobs:
   create:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/controller-monorepo.yml
+++ b/.github/workflows/controller-monorepo.yml
@@ -25,6 +25,11 @@ on:
         description: Directory with applications
         required: true
         type: string
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
     outputs:
       apps:
         description: "Applications"
@@ -38,7 +43,7 @@ on:
 
 jobs:
   monorepo:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## what
* Use `self-hosted-default` gha runners

## references
* DEV-2353 Review workflows in the cloudposse org for specific runs-on settings on self-hosted runners and ensure they have the correct labels and include core-auto
